### PR TITLE
Use public npm registry for composite actions

### DIFF
--- a/bundle-analysis/action.yml
+++ b/bundle-analysis/action.yml
@@ -7,6 +7,11 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '18'
+
+  github-packages:
+    description: '(Deprecated) Previously toggled GitHub Packages authentication. No longer used.'
+    required: false
+    default: 'false'
   
   pattern:
     description: 'Glob pattern for files to analyze'

--- a/bundle-analysis/action.yml
+++ b/bundle-analysis/action.yml
@@ -8,11 +8,6 @@ inputs:
     required: false
     default: '18'
   
-  github-packages:
-    description: 'Enable GitHub Packages registry authentication'
-    required: false
-    default: 'false'
-  
   pattern:
     description: 'Glob pattern for files to analyze'
     required: false
@@ -56,13 +51,10 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
-        registry-url: ${{ inputs.github-packages == 'true' && 'https://npm.pkg.github.com' || '' }}
 
     - name: Install dependencies
       shell: bash
       run: npm ci
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.github-packages == 'true' && github.token || '' }}
 
     - name: Build module
       shell: bash

--- a/ci/action.yml
+++ b/ci/action.yml
@@ -7,6 +7,11 @@ inputs:
     description: 'Node.js version to use'
     required: false
     default: '18'
+
+  github-packages:
+    description: '(Deprecated) Previously toggled GitHub Packages authentication. No longer used.'
+    required: false
+    default: 'false'
   
   codecov:
     description: 'Enable Codecov coverage reporting'

--- a/ci/action.yml
+++ b/ci/action.yml
@@ -8,11 +8,6 @@ inputs:
     required: false
     default: '18'
   
-  github-packages:
-    description: 'Enable GitHub Packages registry authentication'
-    required: false
-    default: 'true'
-  
   codecov:
     description: 'Enable Codecov coverage reporting'
     required: false
@@ -51,13 +46,10 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
-        registry-url: ${{ inputs.github-packages == 'true' && 'https://npm.pkg.github.com' || '' }}
 
     - name: Install dependencies
       shell: bash
       run: npm ci
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.github-packages == 'true' && github.token || '' }}
 
     - name: Run linting
       shell: bash

--- a/release/action.yml
+++ b/release/action.yml
@@ -6,11 +6,16 @@ inputs:
   tag:
     description: 'Tag name (optional - defaults to release event tag or latest git tag)'
     required: false
-  
+
   node-version:
     description: 'Node.js version to use'
     required: false
     default: '18'
+
+  github-packages:
+    description: '(Deprecated) Previously toggled GitHub Packages authentication. No longer used.'
+    required: false
+    default: 'false'
   
   build-command:
     description: 'Build command to run'

--- a/release/action.yml
+++ b/release/action.yml
@@ -49,12 +49,9 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
-        registry-url: 'https://npm.pkg.github.com'
 
     - name: Install dependencies
       shell: bash
-      env:
-        NODE_AUTH_TOKEN: ${{ github.token }}
       run: npm ci
 
     - name: Determine tag


### PR DESCRIPTION
## Summary
- remove GitHub Packages authentication from the release, CI, and bundle-analysis composites
- rely on the default public npm registry when installing dependencies in each action

## Testing
- not run (composite action repository)


------
https://chatgpt.com/codex/tasks/task_e_68cced269ae88327884c61d15d902d0f